### PR TITLE
Custom

### DIFF
--- a/twitchio/cooldowns.py
+++ b/twitchio/cooldowns.py
@@ -30,7 +30,7 @@ import time
 
 class RateBucket:
 
-    HTTPLIMIT = 30
+    HTTPLIMIT = 800
     IRCLIMIT = 20
     MODLIMIT = 100
 


### PR DESCRIPTION
- Updated rate limit for http token bucket from 30 to 800 since bearer tokens are now required by twitch.  

- Modified `http.py` to support pagination
- Modified `http.py` to return `full_reply` from twitch for finer control (`{'data': ..., 'total': ..., 'cursor': ...}`).  This avoids excessive calls to fetch a `total` before fetching followers/followings.  This also provides the ability to fetch a desired sample size of followers while removing potential follower bots (i.e., a sequence of users that followed within X seconds of the previous follower).  Additionally, it provides the ability to skip "following" collection when `total` exceeds some threshold using a single request while retaining "following" data that satisfy this criteria.